### PR TITLE
improve get_extended_config_file with expansions

### DIFF
--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -242,6 +242,14 @@ def validate_rule_conf(rule, conf):
 
 
 def get_extended_config_file(name):
+    # Expand tilde if present
+    if name.startswith('~'):
+        name = os.path.expanduser(name)
+
+    # Expand variables if present
+    if '$' in name:
+        name = os.path.expandvars(name)
+
     # Is it a standard conf shipped with yamllint...
     if '/' not in name:
         std_conf = os.path.join(os.path.dirname(os.path.realpath(__file__)),


### PR DESCRIPTION
This PR improves get_extended_config_file function providing it with the ability to expand variables and tilde so you can use more complex values in `extends:`.

Example 1:

```
extends: ~/repos/github.com/freehck/linting-rules/.yamllint
```

Example 2:

```
extends: $HOME/repos/github.com/freehck/linting-rules/.yamllint
```

Example 3:

```
extends: ${HOME}/repos/github.com/freehck/linting-rules/.yamllint
```

This is useful to store company's linting rules in a separate repository.